### PR TITLE
Pass attributes on splice through to generated parser

### DIFF
--- a/src/Comparse.Tactic.GenerateParser.fst
+++ b/src/Comparse.Tactic.GenerateParser.fst
@@ -857,10 +857,11 @@ let gen_parser_aux type_fv force_smt =
     lb_def = parser_fun;
   } in
   let sv = pack_sigelt (Sg_Let { isrec = false; lbs = [parser_letbinding];}) in
-  let sv =
-    if is_opaque then set_sigelt_attrs [(`"opaque_to_smt")] sv
-    else sv
+  let attrs = splice_attrs () in
+  let attrs =
+    if is_opaque then attrs @ [(`"opaque_to_smt"); (`tac_opaque)] else attrs
   in
+  let sv = set_sigelt_attrs attrs sv in
   [sv]
 
 val gen_parser: term -> Tac decls


### PR DESCRIPTION
This change uses the V2 tactics' `splice_attrs` function to get any attributes applied to a spliced generated parser, and applies them to the generated parser itself.

Separately, in the opaque case, the `tac_opaque` attribute is added, in addition to `"opaque_to_smt"`, reducing the degree to which parsers/serializers can be unintentionally normalized in tactics proofs (e.g., as part of the `assumption` tactic, which may try to normalize hypotheses in the context as part of its execution, potentially leading to slowdown and high memory usage for complex generated parsers).