### PR TITLE
chore: update to Z3 4.15.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ FSTAR_EXTRACT = --extract '-* +Comparse -Comparse.Tactic'
 # Allowed warnings:
 # - (Warning 242) Definitions of inner let-rec ... and its enclosing top-level letbinding are not encoded to the solver, you will only be able to reason with their types
 # - (Warning 335) Interface ... is admitted without an implementation 
-FSTAR_FLAGS = $(FSTAR_INCLUDE_DIRS) --cache_checked_modules --already_cached '+Prims +FStar' --warn_error '@0..1000' --warn_error '+242-335' --cache_dir cache --odir obj --cmi
+FSTAR_FLAGS = $(FSTAR_INCLUDE_DIRS) --cache_checked_modules --already_cached '+Prims +FStar' --warn_error '@0..1000' --warn_error '+242-335' --cache_dir cache --odir obj --cmi --z3version 4.15.3
 
 .PHONY: all clean
 


### PR DESCRIPTION
Currently, DY* and Comparse use different default versions of Z3, which can lead to inconsistencies and compatibility issues. This PR updates Comparse to use the same Z3 version as DY*, ensuring consistency across both projects.